### PR TITLE
Add prune_reverse parameter

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,15 @@ neighbors, just the distances. Thank you to reporter
 * New parameter for `prepare_search_graph`: `use_alt_metric`. This behaves like
 the existing `use_alt_metric` parameters in other functions and may speed up
 the index preparation step in e.g. `rnnd_build`.
+* New parameter for `rnnd_build` and `prepare_search_graph`: `prune_reverse`. If
+set to `TRUE` the reverse graph will be pruned using the
+`pruning_degree_multiplier` parameter before any diversification. This can help
+prevent an excessive amount of time being spent in the diversification step in
+the case where an item has a large number of neighbors (in the reverse graph
+this can be as large as the number of items in the dataset). Pruning of the
+merged graph still occurs, so this is an additional pruning step. This should
+have little effect on search results, but for backwards compatibility, the
+default is `FALSE`.
 
 # rnndescent 0.1.3
 

--- a/man/prepare_search_graph.Rd
+++ b/man/prepare_search_graph.Rd
@@ -11,6 +11,7 @@ prepare_search_graph(
   use_alt_metric = TRUE,
   diversify_prob = 1,
   pruning_degree_multiplier = 1.5,
+  prune_reverse = FALSE,
   n_threads = 0,
   verbose = FALSE,
   obs = "R"
@@ -120,6 +121,13 @@ setting this to \code{1.5} will keep all the forward neighbors and then
 half as many of the reverse neighbors, although exactly which neighbors are
 retained is also dependent on any occlusion pruning that occurs. Set this
 to \code{NULL} to skip this step.}
+
+\item{prune_reverse}{If \code{TRUE}, prune the reverse neighbors of each item
+before the reverse graph diversification step using
+\code{pruning_degree_multiplier}. Because the number of reverse neighbors can be
+much larger than the number of forward neighbors, this can help to avoid
+excessive computation during the diversification step, with little overall
+effect on the final search graph. Default is \code{FALSE}.}
 
 \item{n_threads}{Number of threads to use.}
 

--- a/man/rnnd_build.Rd
+++ b/man/rnnd_build.Rd
@@ -21,6 +21,7 @@ rnnd_build(
   n_search_trees = 1,
   pruning_degree_multiplier = 1.5,
   diversify_prob = 1,
+  prune_reverse = FALSE,
   n_threads = 0,
   verbose = FALSE,
   progress = "bar",
@@ -220,6 +221,13 @@ then the nearer neighbor \code{p} is said to "occlude" \code{q}. It is likely th
 the neighbor list of \code{i}. You may also set this to \code{NULL} to skip any
 occlusion pruning. Note that occlusion pruning is carried out twice, once
 to the forward neighbors, and once to the reverse neighbors.}
+
+\item{prune_reverse}{If \code{TRUE}, prune the reverse neighbors of each item
+before the reverse graph diversification step using
+\code{pruning_degree_multiplier}. Because the number of reverse neighbors can be
+much larger than the number of forward neighbors, this can help to avoid
+excessive computation during the diversification step, with little overall
+effect on the final search graph. Default is \code{FALSE}.}
 
 \item{n_threads}{Number of threads to use.}
 

--- a/tests/testthat/test_rnnd.R
+++ b/tests/testthat/test_rnnd.R
@@ -24,3 +24,13 @@ iris_knn <- rnnd_knn(
   k = 4,
 )
 expect_equal(iris_knn, iris_index$graph)
+
+set.seed(1337)
+iris_index_pr <- rnnd_build(
+  data = ui10,
+  k = 4,
+  diversify_prob = 1.0,
+  prune_reverse = TRUE
+)
+iris_query_pr <- rnnd_query(index = iris_index_pr, query = ui10, k = 4)
+expect_equal(iris_query_pr, iris_bf)


### PR DESCRIPTION
Adds a new option to prune the reversed knn graph before diversification to avoid extended occlusion pruning when hubs are present. Has no effect on search quality in my tests, but can save time.