### PR TITLE
Better dqrng compatibility changes

### DIFF
--- a/inst/include/dqsample.h
+++ b/inst/include/dqsample.h
@@ -27,7 +27,7 @@ namespace dqsample {
 
 // sample size items in the range [0 + offset, end + offset)
 template <typename INT>
-inline auto replacement(dqrng::rng64_t &rng, INT end, INT size, int offset)
+inline auto replacement(std::shared_ptr<dqrng::random_64bit_generator> &rng, INT end, INT size, int offset)
     -> std::vector<INT> {
   std::vector<INT> result(size);
   auto generator = [=, &rng]() -> INT {
@@ -38,7 +38,7 @@ inline auto replacement(dqrng::rng64_t &rng, INT end, INT size, int offset)
 }
 
 template <typename INT>
-auto no_replacement_shuffle(dqrng::rng64_t &rng, INT end, INT size,
+auto no_replacement_shuffle(std::shared_ptr<dqrng::random_64bit_generator> &rng, INT end, INT size,
                             int offset = 0) -> std::vector<INT> {
   std::vector<INT> tmp(end);
   std::iota(tmp.begin(), tmp.end(), static_cast<INT>(offset));
@@ -52,7 +52,7 @@ auto no_replacement_shuffle(dqrng::rng64_t &rng, INT end, INT size,
 }
 
 template <typename INT, typename SET>
-auto no_replacement_set(dqrng::rng64_t &rng, INT end, INT size, int offset)
+auto no_replacement_set(std::shared_ptr<dqrng::random_64bit_generator> &rng, INT end, INT size, int offset)
     -> std::vector<INT> {
   std::vector<INT> result(size);
 
@@ -70,7 +70,7 @@ auto no_replacement_set(dqrng::rng64_t &rng, INT end, INT size, int offset)
 // Sample size points from the range [0 + offset, end + offset) with or without
 // replacement
 template <typename INT>
-inline auto sample(std::vector<INT> &result, dqrng::rng64_t &rng, INT end,
+inline auto sample(std::vector<INT> &result, std::shared_ptr<dqrng::random_64bit_generator> &rng, INT end,
                    INT size, bool replace = false, int offset = 0) -> bool {
   if (replace || size <= 1) {
     result = replacement<INT>(rng, end, size, offset);

--- a/inst/include/rnndescent/random.h
+++ b/inst/include/rnndescent/random.h
@@ -45,14 +45,8 @@ inline auto r_seed() -> uint64_t {
   return dqrng::convert_seed<uint64_t>(seed);
 }
 
-inline auto create_dqrng() -> dqrng::rng64_t {
-  auto seed1 = r_seed();
-  auto seed2 = r_seed();
-  return dqrng::generator<pcg64>(seed1, seed2);
-}
-
-inline auto create_dqrng(uint64_t seed, uint64_t seed2) -> dqrng::rng64_t {
-  return dqrng::generator<pcg64>(seed, seed2);
+inline auto create_dqrng() -> std::shared_ptr<dqrng::random_64bit_generator> {
+  return std::make_shared<dqrng::random_64bit_wrapper<pcg64>>();
 }
 
 inline auto combine_seeds(uint32_t msw, uint32_t lsw) -> uint64_t {
@@ -71,7 +65,8 @@ struct TauRand : public tdoann::RandomGenerator {
   std::unique_ptr<tdoann::tau_prng> prng{nullptr};
 
   TauRand(uint64_t seed, uint64_t seed2) {
-    dqrng::rng64_t rng = create_dqrng(seed, seed2);
+    std::shared_ptr<dqrng::random_64bit_generator> rng = create_dqrng();
+    rng->seed(seed, seed2);
 
     // Stitch together 3 64-bit ints from 6 32-bit ones
     std::vector<uint32_t> tau_seeds32;
@@ -114,14 +109,20 @@ public:
 template <typename Int>
 class DQIntSampler : public tdoann::RandomIntGenerator<Int> {
 private:
-  dqrng::rng64_t rng;
+  std::shared_ptr<dqrng::random_64bit_generator> rng;
 
 public:
-  // Not thread safe
-  DQIntSampler() : rng(create_dqrng()) {}
 
-  DQIntSampler(uint64_t seed, uint64_t seed2)
-      : rng(create_dqrng(seed, seed2)) {}
+  // Not thread safe
+  DQIntSampler() : rng(create_dqrng()) {
+    auto seed1 = r_seed();
+    auto seed2 = r_seed();
+    rng->seed(seed1, seed2);
+  }
+
+  DQIntSampler(uint64_t seed, uint64_t seed2) : rng(create_dqrng()) {
+    rng->seed(seed, seed2);
+  }
 
   // Generates a random integer in range [0, n)
   Int rand_int(Int n) override {
@@ -137,6 +138,7 @@ public:
     return result;
   }
 };
+
 
 template <typename Int, template <typename> class RNG>
 class ParallelIntRNGAdapter : public tdoann::ParallelRandomIntProvider<Int> {
@@ -155,9 +157,9 @@ public:
   // random numbers in each window, but they are related to the random number
   // seed
   std::unique_ptr<tdoann::RandomIntGenerator<Int>>
-  get_parallel_instance(uint64_t seed2) override {
-    return std::make_unique<RNG<Int>>(seed, seed2);
-  }
+    get_parallel_instance(uint64_t seed2) override {
+      return std::make_unique<RNG<Int>>(seed, seed2);
+    }
 };
 
 } // namespace rnndescent


### PR DESCRIPTION
Use the original definition of `dqrng::rng64_t` instead of trying to use the new definition.

I think the issues we saw in https://github.com/daqana/dqrng/issues/80 stemming from my original patch are related to creating a new style `dqrng::rng64_t` within parallel code. That is something that is no longer possible, since it now uses `Rcpp::XPtr`.